### PR TITLE
DBのポート転送を削除

### DIFF
--- a/compose.yaml
+++ b/compose.yaml
@@ -26,8 +26,6 @@ services:
       MYSQL_DATABASE: FAMILIA_COPILOT
       MYSQL_USER: user
       MYSQL_PASSWORD: password
-    ports:
-      - 3306:3306
 
 volumes:
   db-data:


### PR DESCRIPTION
なくても動く。
ローカルで立ててるMySQLとポート番号が同じで競合するので消したい。